### PR TITLE
gf180mcu: add Label, BLK and Slot Layers where applicable

### DIFF
--- a/pdks/gf180mcu.json
+++ b/pdks/gf180mcu.json
@@ -139,6 +139,7 @@
                 "LVPWELL 204/0@1",
                 "Nplus 32/0@1",
                 "Pplus 31/0@1",
+                "Dualgate 55/0@1",
                 "Resistor 62/0@1",
                 "Contact 33/0@1"
             ]


### PR DESCRIPTION
As title says. There is probably more layers to add for the comp/poly2 layers. I will add them when I find out.