### PR TITLE
Update sky130.json to fix typo

### DIFF
--- a/pdks/sky130.json
+++ b/pdks/sky130.json
@@ -1,5 +1,5 @@
 {
-    "tech_name": "sky130",
+    "tech_name": "sky130A",
     "layer_group_definitions": [
         {
             "name": "li1.Visible",


### PR DESCRIPTION
name was set to sky130A but the technology is named sky130A in the sky130A.lyt in the PDK